### PR TITLE
Fix for "Running API Call /pre-processor/pre_process_folder causes test data in source location (hd1) to be deleted #27"

### DIFF
--- a/cdr_plugin_folder_to_folder/pre_processing/Pre_Processor.py
+++ b/cdr_plugin_folder_to_folder/pre_processing/Pre_Processor.py
@@ -82,7 +82,10 @@ class Pre_Processor:
         return self.meta_service.file_hash(file_path)
 
     def prepare_folder(self, folder_to_process):
-        if folder_to_process.startswith(self.storage.hd1()):
+        abs_path_folder_to_process = os.path.abspath(folder_to_process)
+        abs_path_hd1 = os.path.abspath(self.storage.hd1())
+
+        if abs_path_folder_to_process.startswith(abs_path_hd1):
             return folder_to_process
 
         dirname = os.path.join(self.storage.hd1(), os.path.basename(folder_to_process))

--- a/tests/unit/pre_processing/test_Pre_Processor.py
+++ b/tests/unit/pre_processing/test_Pre_Processor.py
@@ -57,6 +57,7 @@ class test_Pre_Processor(TestCase):
 
         filename = os.path.basename(self.test_file)
         folder_to_process = self.pre_processor.prepare_folder(self.temp_dir)
+        assert folder_exists(self.temp_dir)
         assert folder_to_process.startswith(self.pre_processor.storage.hd1())
         assert os.path.isdir(folder_to_process)
         assert os.path.isfile(os.path.join(folder_to_process, filename))


### PR DESCRIPTION
This fixes https://github.com/filetrust/cdr-plugin-folder-to-folder-bugs/issues/27