### PR TITLE
Change "Completed OK" and "Completed with Errors" (issue 353)

### DIFF
--- a/cdr_plugin_folder_to_folder/metadata/Metadata.py
+++ b/cdr_plugin_folder_to_folder/metadata/Metadata.py
@@ -182,6 +182,9 @@ class Metadata:
     def get_original_hash(self):
         return self.data.get('original_hash')
 
+    def get_rebuild_hash(self):
+        return self.data.get('rebuild_hash')
+
     def get_file_hash(self):
         return self.file_hash
 

--- a/cdr_plugin_folder_to_folder/pre_processing/Status.py
+++ b/cdr_plugin_folder_to_folder/pre_processing/Status.py
@@ -16,9 +16,10 @@ class FileStatus:                                     # todo move to separate fi
     INITIAL       = "Initial"
     NOT_COPIED    = "Will not be copied"
     IN_PROGRESS   = "In Progress"
-    COMPLETED     = "Completed Successfully"
+    COMPLETED     = "THE ORIGINAL FILE IS CLEANED"
+    NO_CLEANING_NEEDED = "THE ORIGINAL FILE WAS ALREADY CLEAN"
     NOT_SUPPORTED = "The file type is not currently supported"
-    FAILED        = "Completed with errors"
+    FAILED        = "UNABLE TO CLEAN THE FILE"
     TO_PROCESS    = "To Process"
     NONE          = "None"
 

--- a/cdr_plugin_folder_to_folder/processing/Endpoint_Service.py
+++ b/cdr_plugin_folder_to_folder/processing/Endpoint_Service.py
@@ -64,7 +64,10 @@ class Endpoint_Service:
             self.endpoints = endpoints
 
     def endpoints_count(self):
-        return len(self.endpoints)
+        if self.endpoints:
+            return len(self.endpoints)
+        else:
+            return 0
 
     def get_endpoint(self):
         endpoint = None

--- a/cdr_plugin_folder_to_folder/processing/File_Processing.py
+++ b/cdr_plugin_folder_to_folder/processing/File_Processing.py
@@ -367,8 +367,13 @@ class File_Processing:
 
     def finalize_completed(self, dir, hash):
         self.status.add_completed()
-        self.meta_service.set_status(dir, FileStatus.COMPLETED)
-        self.hash_json.update_status(hash, FileStatus.COMPLETED)
+        metadata = self.meta_service.get_from_file(dir)
+        if metadata.get_original_hash() == metadata.get_rebuild_hash():
+            self.meta_service.set_status(dir, FileStatus.NO_CLEANING_NEEDED)
+            self.hash_json.update_status(hash, FileStatus.NO_CLEANING_NEEDED)
+        else:
+            self.meta_service.set_status(dir, FileStatus.COMPLETED)
+            self.hash_json.update_status(hash, FileStatus.COMPLETED)
         self.meta_service.set_error(dir, "none")
 
     def finalize_failed(self, dir, hash):

--- a/cdr_plugin_folder_to_folder/processing/Loops.py
+++ b/cdr_plugin_folder_to_folder/processing/Loops.py
@@ -191,7 +191,7 @@ class Loops(object):
             elif (FileStatus.NOT_SUPPORTED == file_status):
                 destination_path = self.storage.hd2_not_supported(key)
             else:
-                return
+                continue
 
             if destination_path:
                 if folder_exists(destination_path):

--- a/cdr_plugin_folder_to_folder/processing/Loops.py
+++ b/cdr_plugin_folder_to_folder/processing/Loops.py
@@ -183,10 +183,15 @@ class Loops(object):
             source_path = self.storage.hd2_data(key)
             destination_path = ""
 
-            if (FileStatus.COMPLETED == json_list[key]["file_status"]):
+            file_status = json_list[key]["file_status"]
+
+            if (FileStatus.COMPLETED == file_status) or \
+               (FileStatus.NO_CLEANING_NEEDED == file_status):
                 destination_path = self.storage.hd2_processed(key)
-            elif (FileStatus.NOT_SUPPORTED == json_list[key]["file_status"]):
+            elif (FileStatus.NOT_SUPPORTED == file_status):
                 destination_path = self.storage.hd2_not_supported(key)
+            else:
+                return
 
             if destination_path:
                 if folder_exists(destination_path):

--- a/cdr_plugin_folder_to_folder/processing/Loops.py
+++ b/cdr_plugin_folder_to_folder/processing/Loops.py
@@ -200,6 +200,10 @@ class Loops(object):
 
     def LoopHashDirectoriesInternal(self, thread_count, do_single):
 
+        log_message = f"LoopHashDirectoriesInternal started with {thread_count} threads"
+        self.events.add_log(log_message)
+        log_info(log_message)
+
         self.endpoint_service.get_endpoints()
 
         if folder_exists(self.storage.hd2_data()) is False:
@@ -213,21 +217,19 @@ class Loops(object):
         if not isinstance(do_single,bool):
             raise TypeError("thread_count must be a integer")
 
-        log_message = f"LoopHashDirectoriesInternal started with {thread_count} threads"
+        log_message = f"LoopHashDirectoriesInternal updating hash.json file"
         self.events.add_log(log_message)
         log_info(log_message)
 
         json_list = self.updateHashJson()
 
-        log_message = f"LoopHashDirectoriesInternal started with {thread_count} threads"
-        self.events.add_log(log_message)
-        log_info(log_message)
-
         threads = list()
 
         process_index   = 0
 
-        log_info(message=f'before Mapping thread_data for {len(json_list)} files')
+        log_message = f'before Mapping thread_data for {len(json_list)} files'
+        self.events.add_log(log_message)
+        log_info(message=log_message)
         thread_data = []
 
         self.endpoint_service.StartServiceThread()
@@ -269,7 +271,10 @@ class Loops(object):
         # for index, thread in enumerate(threads):
         #     thread.join()
 
-        log_info(message=f'after mapped thread_data, there are {len(thread_data)} mapped items')
+        log_message = f'after mapped thread_data, there are {len(thread_data)} mapped items'
+        self.events.add_log(log_message)
+        log_info(message=log_message)
+
         #thread_data = thread_data[:500]
         #log_info(message=f'to start with only processing {len(thread_data)} thread_data items')
         pool = ThreadPool(thread_count)

--- a/tests/unit/pre_processing/test_Status.py
+++ b/tests/unit/pre_processing/test_Status.py
@@ -19,13 +19,14 @@ class test_Status(Temp_Config):
         self.storage = self.status.storage
 
     def test__FileStatus(self):
-        assert inspect.getmembers(FileStatus, lambda a: type(a) is str) == [  ('COMPLETED'      , 'Completed Successfully'                           ),
-                                                                              ('FAILED'         , 'Completed with errors'                            ),
+        assert inspect.getmembers(FileStatus, lambda a: type(a) is str) == [  ('COMPLETED'      , 'THE ORIGINAL FILE IS CLEANED'                     ),
+                                                                              ('FAILED'         , 'UNABLE TO CLEAN THE FILE'                         ),
                                                                               ('INITIAL'        , 'Initial'                                          ),
                                                                               ('IN_PROGRESS'    , 'In Progress'                                      ),
                                                                               ('NONE'           , 'None'                                             ),
                                                                               ('NOT_COPIED'     , 'Will not be copied'                               ),
                                                                               ('NOT_SUPPORTED'  , 'The file type is not currently supported'         ),
+                                                                              ('NO_CLEANING_NEEDED'  , 'THE ORIGINAL FILE WAS ALREADY CLEAN'         ),
                                                                               ('TO_PROCESS'     , 'To Process'                                       ),
                                                                               ('__module__'     , 'cdr_plugin_folder_to_folder.pre_processing.Status')]
 

--- a/tests/unit/processing/test_Endpoint_Service.py
+++ b/tests/unit/processing/test_Endpoint_Service.py
@@ -51,6 +51,8 @@ class test_Endpoint_Service(Temp_Config):
         self.endpoint_service.config.sdk_servers_api = 'http://not-exising-domain.xyz'
         self.endpoint_service.get_endpoints()
         assert not self.endpoint_service.endpoints
+        endpoint = self.endpoint_service.get_endpoint()
+        assert endpoint is None
         self.endpoint_service.config.sdk_servers_api = config_sdk_servers_url
         self.endpoint_service.config.endpoints = config_endpoints
 
@@ -58,5 +60,6 @@ class test_Endpoint_Service(Temp_Config):
         self.endpoint_service.StartServiceThread()
         self.endpoint_service.StopServiceThread()
         assert self.endpoint_service.service_thread_on is False
+
 
 

--- a/tests/unit/processing/test_Loops.py
+++ b/tests/unit/processing/test_Loops.py
@@ -101,5 +101,10 @@ class test_Loops(Temp_Config):
         assert self.loops.LoopHashDirectoriesInternal(thread_count=30, do_single=False) is False
         self.loops.config.hd2_todo_location = hd2_todo_location
 
+    def test_LoopHashDirectoriesInternal_no_endpoints(self):
+        endpoints = self.loops.endpoint_service.endpoints
+        self.loops.endpoint_service.endpoints = None
+        assert self.loops.LoopHashDirectoriesInternal(thread_count=30, do_single=False)
+        self.loops.endpoint_service.endpoints = endpoints
 
 


### PR DESCRIPTION
Now the following metadata rebuild states are used:

"ORIGINAL FILE IS CLEANED", 
"ORIGINAL FILE WAS ALREADY CLEAN" 
"UNABLE TO CLEAN FILE" 

Fixes #353 , #356
and https://github.com/filetrust/cdr-plugin-folder-to-folder-bugs/issues/36

This also contains modifications that help to verify that compilation of hash.json currently takes significant time 
Related to #405