### PR TITLE
Fix pre-processing incase of metadata.json is missing for a file

### DIFF
--- a/cdr_plugin_folder_to_folder/metadata/Metadata.py
+++ b/cdr_plugin_folder_to_folder/metadata/Metadata.py
@@ -49,7 +49,7 @@ class Metadata:
             delta = tok - tik
             self.set_file_hash_calculation_time(delta.total_seconds())
 
-            if self.exists():
+            if self.exists() and self.metadata_file_exists():
                 self.get_from_file()
             else:
                 self.create(file_path)

--- a/tests/unit/metadata/test_Metadata.py
+++ b/tests/unit/metadata/test_Metadata.py
@@ -94,5 +94,18 @@ class test_Metadata(TestCase):
     def test_delete(self):
         assert self.metadata.delete() is False
 
+    def test_add_file_after_delete_should_not_fail(self):
+        metadata = self.metadata
+        # adding file first time
+        assert metadata.add_file(self.file_path) == self.file_hash                              # add file and get file hash as return value
+        assert metadata.exists() is True                                                        # confirm metadata folder now exists
+        file_delete(self.metadata.metadata_file_path())                                         # Delete the metadata.json path
+        assert metadata.add_file(self.file_path) == self.file_hash                              # Try to add file again, this should not fail
+        assert metadata.exists() is True
+
+        #clean up
+        assert self.metadata.delete() is True
+        assert folder_not_exists(self.metadata.metadata_folder_path())
+
     def test_metadata_file_path(self):
         assert self.metadata.metadata_folder_path() is None


### PR DESCRIPTION
## Issue

When doing pre-processing/load files and metadata.json for a file has been removed or missing, the pre-processing/load files would fail

## Summary of Fix

Ensured that we check if metadata.json file exists and not just rely on hash/metadata directory is present for the file

## Testing

To easily reproduce this issue:
1. Configure any scenario for testing
2. Clear Data (This will remove HD2)
3. Load File
4. Go to HD2 and delete metadata.json for any of the files
5. Load File (This should fail without this fix)

https://github.com/filetrust/cdr-plugin-folder-to-folder/issues/546