### PR TITLE
Utilize an older version of minio - one that works

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -143,7 +143,7 @@ services:
 
   # minio
   minio:
-    image: minio/minio:latest
+    image: minio/minio@sha256:7f402afa859f4d92ac78ba1c816f6fc24c844c4244a1a33a7230e99cbc13142f
     volumes:
       - ${HOST_MINIO_LOCATION}:/data
     ports:


### PR DESCRIPTION
Addresses https://github.com/filetrust/cdr-plugin-folder-to-folder-bugs/issues/72

Newly deployed EC2 instances would pull the latest version of minio from the docker hub.
The latest version of minio turned to be incompatible with our setup.
With an older version it all works