### PR TITLE
Add cifs-utils to f2f plugin

### DIFF
--- a/cdr_plugin_folder_to_folder/Dockerfile
+++ b/cdr_plugin_folder_to_folder/Dockerfile
@@ -1,6 +1,6 @@
 FROM    python:rc-alpine3.12
 RUN     apk update && apk upgrade && \
-        apk add --no-cache bash git openssh gcc libc-dev linux-headers
+        apk add --no-cache bash git openssh gcc libc-dev linux-headers cifs-utils
 
 WORKDIR /app
 # Add wait-for-it, use to check if ES is up before starting the server


### PR DESCRIPTION
## Summary

Added cifs-utils to f2f container. This is useful to mount smb shared folder

## Issue
[add cifs-utils to F2F container #476](https://github.com/filetrust/cdr-plugin-folder-to-folder/issues/476)